### PR TITLE
making vault host configurable

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -19,8 +19,15 @@ class Client
 
     public function __construct(array $options = [], LoggerInterface $logger = null, GuzzleClient $client = null)
     {
+        $base_uri = 'http://127.0.0.1:8200';
+        if (isset($options['base_uri'])) {
+            $base_uri = $options['base_uri'];
+        } else if (getenv('VAULT_ADDR') !== false) {
+            $base_uri = getenv('VAULT_ADDR');
+        }
+
         $options = array_replace([
-            'base_uri' => 'http://127.0.0.1:8200',
+            'base_uri' => $base_uri,
             'http_errors' => false,
             'headers' => [
                 'User-Agent' => 'Vault-PHP-SDK/1.0',


### PR DESCRIPTION
- retains default of `http://127.0.0.1:8200` if not otherwise specified
- if `VAULT_ADDR` environment variable is supplied, that value will be used
- is `base_uri` key is supplied in the `$options` array, that value will be used